### PR TITLE
handle http errors correctly by using NSURLSession. fixes #4

### DIFF
--- a/ios/sdk/O2MC/Dispatcher.h
+++ b/ios/sdk/O2MC/Dispatcher.h
@@ -9,9 +9,11 @@
 
 @interface Dispatcher : NSObject {
     NSString* _appName;
+    NSURLSession* _session;
 }
 
 - (id)init:(NSString*)appName;
 -(void) dispatch:(NSString*)endpoint :(NSMutableDictionary *)funnel;
 -(NSMutableDictionary *) getGeneralInfo;
+-(NSURLSession *) urlSession;
 @end


### PR DESCRIPTION
Network errors are now handled properly by retrying and keeping the un-pushed events in memory.
This fix also uses the newer and recommended NSURLSession API instead of the deprecated NSConnection API.