### PR TITLE
Feat/android retries

### DIFF
--- a/android/app/src/main/java/io/o2mc/app/App.java
+++ b/android/app/src/main/java/io/o2mc/app/App.java
@@ -14,6 +14,7 @@ public class App extends Application {
 //        o2mc = new O2MC(null, null);
         o2mc = new O2MC(this, "http://10.0.2.2:5000/events");
         o2mc.setDispatchInterval(8);
+        o2mc.setMaxRetries(5);
     }
 
     public static O2MC getO2mc() {

--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -32,6 +32,7 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
 
     private Timer timer = new Timer(); // timer used for dispatching events
     private int dispatchInterval; // interval on which to send events
+    private int maxRetries; // max amount of times to retry sending batches
 
     private DeviceManager deviceManager;
     private EventGenerator eventGenerator;
@@ -64,6 +65,18 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
         this.eventBus = new EventBus();
 
         BatchDispatcher.getInstance().setO2mc(this);
+    }
+
+    /**
+     * Sets the max amount of retries for generating batches. Helps to reduce cpu usage / battery draining.
+     *
+     * @param maxRetries the amount of times the SDK should try to resend a batch before giving up
+     */
+    public void setMaxRetries(int maxRetries) {
+        // Setting a max below zero or zero makes no sense -- then you'd never send any batches.
+        if (maxRetries > 0) {
+            this.maxRetries = maxRetries;
+        }
     }
 
     /**
@@ -170,6 +183,7 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
     public void dispatchSuccess() {
         if (BuildConfig.DEBUG) Log.d(TAG, "Dispatch successful.");
         reset();
+        batchGenerator.lastBatchSucceeded();
     }
 
     /**
@@ -184,6 +198,8 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
      */
     public void dispatchFailure() {
         if (BuildConfig.DEBUG) Log.d(TAG, "Dispatch failure. Not clearing EventBus.");
+
+        batchGenerator.lastBatchFailed();
     }
 
     /**
@@ -217,6 +233,15 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
             // Initialize batchGenerator meta data on the first run
             if (batchGenerator.firstRun()) {
                 batchGenerator.setDeviceInformation(deviceManager.generateDeviceInformation());
+            }
+
+            // Don't try resending a batch if the max retries limit has exceeded
+            if (batchGenerator.getRetries() >= maxRetries) {
+                if (BuildConfig.DEBUG)
+                    Log.w(TAG, "run: Max retries limit has been reached. Not trying to resend batch.");
+                timer.cancel();
+                timer.purge();
+                return;
             }
 
             if (BuildConfig.DEBUG)

--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -8,10 +8,10 @@ import android.util.Log;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import io.o2mc.sdk.business.BatchDispatcher;
 import io.o2mc.sdk.business.BatchGenerator;
 import io.o2mc.sdk.business.DeviceManager;
 import io.o2mc.sdk.business.EventBus;
-import io.o2mc.sdk.business.EventDispatcher;
 import io.o2mc.sdk.business.EventGenerator;
 import io.o2mc.sdk.domain.Batch;
 import io.o2mc.sdk.domain.Event;
@@ -63,7 +63,7 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
         this.batchGenerator = new BatchGenerator();
         this.eventBus = new EventBus();
 
-        EventDispatcher.getInstance().setO2mc(this);
+        BatchDispatcher.getInstance().setO2mc(this);
     }
 
     /**
@@ -223,7 +223,7 @@ public class O2MC implements Application.ActivityLifecycleCallbacks {
                 Log.i(TAG, String.format("run: Dispatching batch with '%s' events.", eventBus.getEvents().size()));
 
             Batch b = batchGenerator.generateBatch(eventBus.getEvents());
-            EventDispatcher.getInstance().post(endpoint, b);
+            BatchDispatcher.getInstance().post(endpoint, b);
         }
     }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/BatchDispatcher.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/BatchDispatcher.java
@@ -23,9 +23,9 @@ import okhttp3.Response;
  * Singleton class, guaranteed to have only one instance in the apps lifecycle.
  * Sends events in a thread-safe manner.
  */
-public class EventDispatcher {
+public class BatchDispatcher {
 
-    private static final String TAG = "EventDispatcher";
+    private static final String TAG = "BatchDispatcher";
 
     private static Gson gson;
     private static O2MC o2mc;
@@ -36,11 +36,11 @@ public class EventDispatcher {
     // ==========================================
     // region Start singleton technicalities
     // ==========================================
-    private static EventDispatcher instance;
+    private static BatchDispatcher instance;
 
-    public static synchronized EventDispatcher getInstance() {
+    public static synchronized BatchDispatcher getInstance() {
         if (instance == null) {
-            instance = new EventDispatcher();
+            instance = new BatchDispatcher();
             gson = new Gson();
         }
         return instance;
@@ -67,7 +67,7 @@ public class EventDispatcher {
             client.newCall(request).enqueue(new Callback() {
                 @Override
                 public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                    EventDispatcher.getInstance().failureCallback();
+                    BatchDispatcher.getInstance().failureCallback();
 
                     if (BuildConfig.DEBUG)
                         Log.e(TAG, String.format("Unable to post data: '%s'", e.getMessage()));
@@ -77,7 +77,7 @@ public class EventDispatcher {
                 public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
                     if (response.isSuccessful()) {
                         // Http response indicates success, inform user and SDK
-                        EventDispatcher.getInstance().successCallback();
+                        BatchDispatcher.getInstance().successCallback();
                         if (response.body() == null) {
                             if (BuildConfig.DEBUG)
                                 Log.w(TAG, "onResponse: empty http response from backend");
@@ -94,7 +94,7 @@ public class EventDispatcher {
                     } else {
                         try {
                             // Http response indicates failure, inform user and SDK
-                            EventDispatcher.getInstance().failureCallback();
+                            BatchDispatcher.getInstance().failureCallback();
 
                             if (BuildConfig.DEBUG)
                                 Log.w(TAG, String.format("onResponse: Http response indicates failure: '%s'", response.body().string()));
@@ -106,7 +106,7 @@ public class EventDispatcher {
                 }
             });
         } catch (IllegalArgumentException | NullPointerException e) {
-            EventDispatcher.getInstance().failureCallback();
+            BatchDispatcher.getInstance().failureCallback();
 
             if (BuildConfig.DEBUG)
                 Log.e(TAG, "post: Failed to dispatch events", e);
@@ -124,7 +124,7 @@ public class EventDispatcher {
     }
 
     public void setO2mc(O2MC o2mc) {
-        EventDispatcher.o2mc = o2mc;
+        BatchDispatcher.o2mc = o2mc;
 
         if (BuildConfig.DEBUG)
             Log.d(TAG, "Set o2mc field.");

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/BatchGenerator.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/BatchGenerator.java
@@ -22,6 +22,8 @@ public class BatchGenerator {
 
     private DeviceInformation deviceInformation;
 
+    private int retries = 0; // represents the amount of times in a row batches have failed to be sent
+
     /**
      * Tells whether or not we're about to run for the first time.
      *
@@ -42,7 +44,32 @@ public class BatchGenerator {
                 deviceInformation,
                 Util.generateTimestamp(),
                 events,
-                batchCounter++ /*add 1 to the counter after this statement*/
+                batchCounter++, /*add 1 to the counter after this statement*/
+                retries
         );
+    }
+
+    /**
+     * Called when the most recent batch has failed to be processed by the backend.
+     */
+    public void lastBatchFailed() {
+        retries++;
+
+        if (BuildConfig.DEBUG)
+            Log.d(TAG, String.format("Last batch failed. Retries is '%s' now.", retries));
+    }
+
+    /**
+     * Called when the most recent batch has successfully been processed by the backend.
+     */
+    public void lastBatchSucceeded() {
+        retries = 0;
+
+        if (BuildConfig.DEBUG)
+            Log.d(TAG, String.format("Last batch succeeded. Retries is '%s' now.", retries));
+    }
+
+    public int getRetries() {
+        return retries;
     }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/EventDispatcher.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/EventDispatcher.java
@@ -134,23 +134,23 @@ public class EventDispatcher {
      * Called upon successful HTTP post
      */
     private void successCallback() {
-        if (o2mc != null) {
-            o2mc.dispatchSuccess();
-        } else {
+        if (o2mc == null) {
             if (BuildConfig.DEBUG)
                 Log.d(TAG, "O2mc variable is null.");
+            return;
         }
+        o2mc.dispatchSuccess();
     }
 
     /**
      * Called upon failure of HTTP post
      */
     private void failureCallback() {
-        if (o2mc != null) {
-            o2mc.dispatchFailure();
-        } else {
+        if (o2mc == null) {
             if (BuildConfig.DEBUG)
                 Log.d(TAG, "O2mc variable is null.");
+            return;
         }
+        o2mc.dispatchFailure();
     }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/domain/Batch.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/domain/Batch.java
@@ -4,19 +4,21 @@ import java.util.List;
 
 /**
  * Represents a batch of Events.
- * Basically contains events and meta data for analytical purposes.
+ * Essentially contains events and meta data for analytical purposes.
  */
 public class Batch {
     private DeviceInformation deviceInformation;
     private String timestamp;
     private List<Event> events;
     private int number;
+    private int retries;
 
-    public Batch(DeviceInformation deviceInformation, String timestamp, List<Event> events, int number) {
+    public Batch(DeviceInformation deviceInformation, String timestamp, List<Event> events, int number, int retries) {
         this.deviceInformation = deviceInformation;
         this.timestamp = timestamp;
         this.events = events;
         this.number = number;
+        this.retries = retries;
     }
 
     public DeviceInformation getDeviceInformation() {


### PR DESCRIPTION
## 2 things

1. Refactored EventDispatcher to the more descriptive BatchDispatcher
2. Implement max retries mechanism for batches.

#### Specifically, now an additional field 'retries' is sent as meta data with each batch. The developer can specify its max.

A developer can now specify this max retries using `o2mc.setMaxRetries(5);`. When this limit is reached, the SDK will no longer try to send batches. This saves battery and data usage when the user is not planning to use the internet any time soon.

Planning to put dispatchInterval and maxRetries in the constructor to enforce usage of both parameters, then overloading it to allow for default values. 