### PR TITLE
update to make timestamp ISO 8601 certified

### DIFF
--- a/android/sdk/src/main/java/io/o2mc/sdk/TimeUtil.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/TimeUtil.java
@@ -1,0 +1,45 @@
+package io.o2mc.sdk;
+
+import android.annotation.SuppressLint;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+/**
+ * Helper class for handling a most common subset of ISO 8601 strings
+ * (in the following format: "2008-03-01T13:00:00+01:00"). It supports
+ * parsing the "Z" timezone, but many other less-used features are
+ * missing.
+ * <p>
+ * See this link for the source:
+ * https://stackoverflow.com/a/10621553/5273299
+ */
+public final class TimeUtil {
+
+    // We can safely ignore this warning, because we're using an ISO standard. Android Studio does
+    // not look at those, and just tells us to use a Java standard -- which is not necessarily
+    // universal.
+    @SuppressLint("SimpleDateFormat")
+    private static final SimpleDateFormat isoFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
+    /**
+     * Transform Calendar to ISO 8601 string.
+     */
+    private static String fromCalendar(final Calendar calendar) {
+        Date date = calendar.getTime();
+
+        String formatted = isoFormat.format(date);
+
+        return formatted.substring(0, 22) + ":" + formatted.substring(22);
+    }
+
+    /**
+     * Get current date and time formatted as ISO 8601 string.
+     */
+    public static String generateTimestamp() {
+        return fromCalendar(GregorianCalendar.getInstance());
+    }
+}

--- a/android/sdk/src/main/java/io/o2mc/sdk/Util.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/Util.java
@@ -7,22 +7,9 @@ import android.util.Log;
 
 import java.sql.Timestamp;
 
-public class Util {
+public final class Util {
 
     private static final String TAG = "Util";
-
-    /**
-     * Generates a timestamp based on current time.
-     *
-     * @return timestamp in String format
-     */
-    @SuppressLint("DefaultLocale")
-    public static String generateTimestamp() {
-        long l = new java.util.Date().getTime();
-        Timestamp t = new Timestamp(l);
-        // TODO: 7/3/18 research timestamp generation for a correct implementation
-        return String.format("%tFT%<tTZ", t);
-    }
 
     /**
      * Checks whether or not the provided interval is valid and reasonable.

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/BatchGenerator.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/BatchGenerator.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import java.util.List;
 
 import io.o2mc.sdk.BuildConfig;
+import io.o2mc.sdk.TimeUtil;
 import io.o2mc.sdk.Util;
 import io.o2mc.sdk.domain.Batch;
 import io.o2mc.sdk.domain.DeviceInformation;
@@ -40,7 +41,7 @@ public class BatchGenerator {
 
         return new Batch(
                 deviceInformation,
-                Util.generateTimestamp(),
+                TimeUtil.generateTimestamp(),
                 events,
                 batchCounter++ /*add 1 to the counter after this statement*/
         );

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/EventGenerator.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/EventGenerator.java
@@ -3,6 +3,7 @@ package io.o2mc.sdk.business;
 import android.util.Log;
 
 import io.o2mc.sdk.BuildConfig;
+import io.o2mc.sdk.TimeUtil;
 import io.o2mc.sdk.Util;
 import io.o2mc.sdk.domain.Event;
 
@@ -17,13 +18,13 @@ public class EventGenerator {
         if (BuildConfig.DEBUG)
             Log.i(TAG, String.format("generateEvent: Generated event with name '%s'", eventName));
 
-        return new Event(eventName, null, Util.generateTimestamp());
+        return new Event(eventName, null, TimeUtil.generateTimestamp());
     }
 
     public Event generateEventWithProperties(String eventName, String value) {
         if (BuildConfig.DEBUG)
             Log.i(TAG, String.format("generateEventWithProperties: Generated event '%s' with value consisting of '%s' characters", eventName, value.length()));
 
-        return new Event(eventName, value, Util.generateTimestamp());
+        return new Event(eventName, value, TimeUtil.generateTimestamp());
     }
 }


### PR DESCRIPTION
Fixes the lint warning, as well as a generally better universal timestamp format.