### PR TITLE
Feat/ios connection retries

### DIFF
--- a/ios/sdk/O2MC/O2MDispatcher.h
+++ b/ios/sdk/O2MC/O2MDispatcher.h
@@ -15,7 +15,7 @@
 }
 
 @property (assign, nonatomic, readonly) NSInteger connRetries;
-@property (assign, nonatomic, readonly) NSInteger connRetriesMax;
+@property (assign, nonatomic) NSInteger connRetriesMax;
 
 - (id)init:(NSString*)appName;
 -(void) dispatch:(NSString*)endpoint :(NSMutableDictionary *)funnel;

--- a/ios/sdk/O2MC/O2MDispatcher.h
+++ b/ios/sdk/O2MC/O2MDispatcher.h
@@ -12,10 +12,14 @@
     NSString* _appName;
     NSURLSession* _session;
     os_log_t _logTopic;
+    int _connRetries;
+    int _connRetriesMax;
 }
 
 - (id)init:(NSString*)appName;
 -(void) dispatch:(NSString*)endpoint :(NSMutableDictionary *)funnel;
 -(NSMutableDictionary *) getGeneralInfo;
+-(void) successHandler;
+-(void) errorHandler;
 -(NSURLSession *) urlSession;
 @end

--- a/ios/sdk/O2MC/O2MDispatcher.h
+++ b/ios/sdk/O2MC/O2MDispatcher.h
@@ -12,9 +12,10 @@
     NSString* _appName;
     NSURLSession* _session;
     os_log_t _logTopic;
-    int _connRetries;
-    int _connRetriesMax;
 }
+
+@property (assign, nonatomic, readonly) NSInteger connRetries;
+@property (assign, nonatomic, readonly) NSInteger connRetriesMax;
 
 - (id)init:(NSString*)appName;
 -(void) dispatch:(NSString*)endpoint :(NSMutableDictionary *)funnel;

--- a/ios/sdk/O2MC/O2MDispatcher.m
+++ b/ios/sdk/O2MC/O2MDispatcher.m
@@ -19,6 +19,8 @@
     self = [super init];
     _appName = appName;
     _logTopic = os_log_create("io.o2mc.sdk", "dispatcher");
+    _connRetries = 0;
+    _connRetriesMax = 5;
     return self;
 }
 
@@ -71,15 +73,26 @@
                         os_log_debug(self->_logTopic, "length (%lu) Funnel -> ( %@ ) has been dispatched to: %@", (unsigned long)[data length], jsonString,     [response URL]);
                     #endif
                     [funnel removeAllObjects];
+                    [self successHandler];
                 }
             } else {
                 os_log(self->_logTopic, "Connection could not be made");
+                [self errorHandler];
             }
         }];
 
         [dataTask resume];
     }
 
+}
+
+-(void) successHandler {
+    // Reset after each successful data post.
+    self->_connRetries = 0;
+}
+
+-(void) errorHandler {
+    self->_connRetries++;
 }
 
 -(NSURLSession *) urlSession {

--- a/ios/sdk/O2MC/O2MTagger.h
+++ b/ios/sdk/O2MC/O2MTagger.h
@@ -35,6 +35,7 @@
 -(void) setEndpoint :(NSString *) endpoint;
 -(void) setAppId :(NSString *) appId;
 -(void) setDispatchInterval :(NSNumber *)dispatchInterval;
+-(void) setMaxRetries :(NSInteger)maxRetries;
 -(void) addToFunnel :(NSString*)funnelKey :(NSDictionary*)funnelData;
 
 //Tracking methods

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -50,7 +50,9 @@ static int objectCount = 0;
     [self.funnel_lock lock];
     if([_funnel count] > 0){
         if(_dispatcher.connRetries < _dispatcher.connRetriesMax) {
-            os_log(self->_logTopic, "Dispatcher has been triggered");
+            #ifdef DEBUG
+                os_log_debug(self->_logTopic, "Dispatcher has been triggered");
+            #endif
             [_dispatcher dispatch :_endpoint :_funnel];
         } else {
             os_log_info(self->_logTopic, "Reached max connection retries (%u), stopping dispatcher.", _dispatcher.connRetriesMax);

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -70,6 +70,12 @@ static int objectCount = 0;
     [self.funnel_lock unlock];
 }
 
+-(void) setMaxRetries :(NSInteger)maxRetries; {
+    if (_dispatcher) {
+        [_dispatcher setConnRetriesMax: maxRetries];
+    }
+}
+
 -(void) addToFunnel :(NSString*)funnelKey :(NSDictionary*)funnelData; {
     [self.funnel_lock lock];
     if([_funnel objectForKey:funnelKey] == nil){

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -48,9 +48,16 @@ static int objectCount = 0;
 
 -(void) dispatch:(NSTimer *)timer;{
     [self.funnel_lock lock];
-    if([_funnel count] > 0 && _dispatcher.connRetries < _dispatcher.connRetriesMax){
-        os_log(self->_logTopic, "Dispatcher has been triggered");
-        [_dispatcher dispatch :_endpoint :_funnel];
+    if([_funnel count] > 0){
+        if(_dispatcher.connRetries < _dispatcher.connRetriesMax) {
+            os_log(self->_logTopic, "Dispatcher has been triggered");
+            [_dispatcher dispatch :_endpoint :_funnel];
+        } else {
+            os_log_info(self->_logTopic, "Reached max connection retries (%u), stopping dispatcher.", _dispatcher.connRetriesMax);
+
+            // Stopping the time based interval loop.
+            [timer invalidate];
+        }
     }
     [self.funnel_lock unlock];
 }

--- a/ios/sdk/O2MC/O2MTagger.m
+++ b/ios/sdk/O2MC/O2MTagger.m
@@ -48,7 +48,7 @@ static int objectCount = 0;
 
 -(void) dispatch:(NSTimer *)timer;{
     [self.funnel_lock lock];
-    if([_funnel count] > 0){
+    if([_funnel count] > 0 && _dispatcher.connRetries < _dispatcher.connRetriesMax){
         os_log(self->_logTopic, "Dispatcher has been triggered");
         [_dispatcher dispatch :_endpoint :_funnel];
     }


### PR DESCRIPTION
Implements the `setMaxRetries` public SDK method on iOS. The behaviour is similar to Android's, see #50.