### PR TITLE
fix undefined reference to getter method after recent refactor

### DIFF
--- a/android/sdk/src/main/java/io/o2mc/sdk/business/batch/BatchBus.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/batch/BatchBus.java
@@ -141,7 +141,7 @@ public class BatchBus {
     }
 
     // The batch ID is the same for every batch in the current user session, doesn't matter if we get the 1st one or the last one
-    String batchId = batches.get(0).getId();
+    String batchId = batches.get(0).getSessionId();
 
     return generateBatch(batchId, allEvents);
   }


### PR DESCRIPTION
Unable to compile the Android SDK after the Batch's `id` property to `sessionId` refactor in commit 74bfcbe8daeb6165c6d1ae6796c5660f9455d82c.