### PR TITLE
add system locale with proposition to split into two properties

### DIFF
--- a/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import io.o2mc.sdk.domain.DeviceInformation;
 import io.o2mc.sdk.exceptions.O2MCDeviceException;
 import io.o2mc.sdk.interfaces.O2MCExceptionNotifier;
+import java.util.Locale;
 
 /**
  * Manages all operations specifically targeted to the user's device.
@@ -38,9 +39,11 @@ public class DeviceManager {
     String os = "android";
     String osVersion = Build.VERSION.RELEASE;
     String deviceName = android.os.Build.MODEL;
+    String localeCountry = app.getResources().getConfiguration().locale.getCountry();
+    String localeLanguage = app.getResources().getConfiguration().locale.getLanguage();
 
     return new DeviceInformation(
-        appId, os, osVersion, deviceName
+        appId, os, osVersion, localeCountry, localeLanguage, deviceName
     );
   }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import io.o2mc.sdk.domain.DeviceInformation;
 import io.o2mc.sdk.exceptions.O2MCDeviceException;
 import io.o2mc.sdk.interfaces.O2MCExceptionNotifier;
+import java.util.Locale;
 
 /**
  * Manages all operations specifically targeted to the user's device.
@@ -38,12 +39,7 @@ public class DeviceManager {
     String os = "android";
     String osVersion = Build.VERSION.RELEASE;
     String deviceName = android.os.Build.MODEL;
-
-    String language =
-        app.getResources().getConfiguration().locale.getCountry(); // should be 'ISO 3166-1'
-    String country =
-        app.getResources().getConfiguration().locale.getLanguage(); // should be 'ISO 639'
-    String locale = country + "_" + language; // 'RFC 4647' standard
+    String locale = Locale.getDefault().toString(); // 'RFC 4647' standard
 
     return new DeviceInformation(
         appId, os, osVersion, locale, deviceName

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/DeviceManager.java
@@ -5,7 +5,6 @@ import android.os.Build;
 import io.o2mc.sdk.domain.DeviceInformation;
 import io.o2mc.sdk.exceptions.O2MCDeviceException;
 import io.o2mc.sdk.interfaces.O2MCExceptionNotifier;
-import java.util.Locale;
 
 /**
  * Manages all operations specifically targeted to the user's device.
@@ -39,11 +38,15 @@ public class DeviceManager {
     String os = "android";
     String osVersion = Build.VERSION.RELEASE;
     String deviceName = android.os.Build.MODEL;
-    String localeCountry = app.getResources().getConfiguration().locale.getCountry();
-    String localeLanguage = app.getResources().getConfiguration().locale.getLanguage();
+
+    String language =
+        app.getResources().getConfiguration().locale.getCountry(); // should be 'ISO 3166-1'
+    String country =
+        app.getResources().getConfiguration().locale.getLanguage(); // should be 'ISO 639'
+    String locale = country + "_" + language; // 'RFC 4647' standard
 
     return new DeviceInformation(
-        appId, os, osVersion, localeCountry, localeLanguage, deviceName
+        appId, os, osVersion, locale, deviceName
     );
   }
 }

--- a/android/sdk/src/main/java/io/o2mc/sdk/domain/DeviceInformation.kt
+++ b/android/sdk/src/main/java/io/o2mc/sdk/domain/DeviceInformation.kt
@@ -7,7 +7,6 @@ data class DeviceInformation(
   val appId: String,
   val os: String,
   val osVersion: String,
-  val localeCountry: String,
-  val localeLanguage: String,
+  val locale: String,
   val name: String
 )

--- a/android/sdk/src/main/java/io/o2mc/sdk/domain/DeviceInformation.kt
+++ b/android/sdk/src/main/java/io/o2mc/sdk/domain/DeviceInformation.kt
@@ -7,5 +7,7 @@ data class DeviceInformation(
   val appId: String,
   val os: String,
   val osVersion: String,
+  val localeCountry: String,
+  val localeLanguage: String,
   val name: String
 )


### PR DESCRIPTION
Added system locale as is requested per #107. 
Proposing to add the `localeCountry` with its respective country code and `localeLanguage` with its respecting language.
It may be useful to have these two separated, because someone in - let's say Belgium - may speak either French or Dutch depending on its location in Belgium. By adding these two properties, you may get a more accurate location prediction in addition to having more potentially interesting data in general.

This is what a batch would look like right now, after this update:
```
{
    "device": {
        "appId": "io.o2mc.appkotlin",
        "localeCountry": "US",
        "localeLanguage": "en",
        "name": "Android SDK built for x86",
        "os": "android",
        "osVersion": "9"
    },
    "events": [
        {
            "name": "MainActivityCreated",
            "timestamp": "2018-08-15T15:12:31+02:00"
        }
    ],
    "number": 0,
    "retries": 0,
    "timestamp": "2018-08-15T15:12:40+02:00"
}
```

Naming may be up for debate, this seemed most logical to me.