### PR TITLE
Implemented dynamic endpoint configuration

### DIFF
--- a/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/O2MC.java
@@ -74,6 +74,24 @@ import static io.o2mc.sdk.util.LogUtil.LogW;
   }
 
   /**
+   * Changes the URL of the backend to send batches to.
+   *
+   * @param endpoint String value of the URL to the backend
+   */
+  public void setEndpoint(String endpoint) {
+    boolean validEndpoint = trackingManager.setEndpoint(endpoint);
+    if (validEndpoint) {
+      // Manager may be stopped earlier because the endpoint was incorrect
+      // Since the endpoint is correct now, resume tracking
+      trackingManager.resume();
+    } else {
+      // Stop tracking if the endpoint is invalid. Events won't be sent to the
+      // backend anyway, it would only waste the user's data bundle by trying.
+      trackingManager.stop();
+    }
+  }
+
+  /**
    * Changes the number of times the SDK should try to resend data to the backend before giving up.
    *
    * @param maxRetries number of times to retry

--- a/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/TrackingManager.java
@@ -55,6 +55,10 @@ public class TrackingManager implements O2MCExceptionNotifier {
     this.batchManager.init(this, endpoint, dispatchInterval, maxRetries);
   }
 
+  public boolean setEndpoint(String endpoint) {
+    return this.batchManager.setEndpoint(endpoint);
+  }
+
   public void setMaxRetries(int maxRetries) {
     this.batchManager.setMaxRetries(maxRetries);
   }

--- a/android/sdk/src/main/java/io/o2mc/sdk/business/batch/BatchManager.java
+++ b/android/sdk/src/main/java/io/o2mc/sdk/business/batch/BatchManager.java
@@ -105,20 +105,23 @@ public class BatchManager extends TimerTask implements Callback {
    *
    * @param endpoint URL in String format
    */
-  private void setEndpoint(String endpoint) {
+  public boolean setEndpoint(String endpoint) {
     if (endpoint == null || endpoint.isEmpty()) {
       trackingManager.notifyException(
           new O2MCEndpointException("Please provide a non-empty endpoint."),
           true); // fatal exception, the next dispatch wouldn't work even if we tried
+      return false;
     } else if (Util.isValidEndpoint(endpoint)) {
       this.endpoint = endpoint;
       this.usingHttpsEndpoint = Util.isHttps(endpoint);
+      return true;
     } else {
       trackingManager.notifyException(new O2MCEndpointException(
               String.format(
                   "Endpoint is incorrect. Tracking events will fail to be dispatched. Please verify the correctness of '%s'.",
                   endpoint)),
           true);  // fatal exception, the next dispatch wouldn't work even if we tried
+      return false;
     }
   }
 


### PR DESCRIPTION
Tested by setting 

```
    o2mc = O2MC(this, null) // init the 'static' field o2mc
    val endpoint = "http://10.0.2.2:5000/events"
    o2mc.setEndpoint(endpoint)
```

instead of 

```
    o2mc = O2MC(this, "http://10.0.2.2:5000/events") // init the 'static' field o2mc
```
in the constructor of `App.kt`.

Observed that a batch was indeed received from a backend.