### PR TITLE
change event's event prop to the refactored value name

### DIFF
--- a/docs/DATA_SPECIFICATION.md
+++ b/docs/DATA_SPECIFICATION.md
@@ -48,13 +48,13 @@ This object is generated after a [`track()`](API.md#track) [`trackWithProperties
 
 ```
 object {
-	string event;
+	string name;
 	object? properties;
 	string timestamp;
 }
 ```
 
-#### event
+#### name
 
 Name of the triggered event.
 


### PR DESCRIPTION
We refactored the `event.event` to a more descriptive `event.name` property. The documentation was lacking behind.